### PR TITLE
Boardeval2 accounts for positions on the board such that its not only…

### DIFF
--- a/src/main/scala/boardeval2.scala
+++ b/src/main/scala/boardeval2.scala
@@ -1,0 +1,67 @@
+import chisel3._
+import chisel3.util._
+
+// This component evaluates the pieces on the board while also giving rows position an additional score
+// This way , lets say a given scenario where the current boardeval is equal but black (or white) has a better score because of the rows position.
+// Furthermore, the boardeval2 will be able to make a decision based on the rows position.
+
+class boardeval2() extends Module {
+  val io = IO(new Bundle {
+    val In = Input(Vec(32, UInt(3.W)))
+    val color = Input(UInt(1.W))
+
+    val score = Output(SInt(8.W))
+  })
+
+  // Need more bits to store the positional score, 5 bits should be enough.
+  val v = Wire(Vec(32, SInt(5.W)))
+
+  for (i <- 0 to 31) {
+    v(i) := 0.S
+  }
+
+  for (i <- 0 to 31) {
+    val row_pos = i.U / 4.U  // Calculate row as hardware value
+    val material_score = WireDefault(0.S(5.W))
+    val position_score = WireDefault(0.S(5.W))
+
+    // Obtain material score as in boardeval1.
+    switch(io.In(i)) {
+      is("b000".U) { material_score := 0.S }
+      is("b001".U) { material_score := 1.S }
+      is("b010".U) { material_score := 3.S }
+      is("b011".U) { material_score := -1.S }
+      is("b100".U) { material_score := -3.S }
+    }
+
+    when(io.In(i) === "b001".U) { // white pawn
+      // row 0 = +3, row 1 = +2, row 2 = +1, row 3+ = 0
+      when(row_pos === 0.U) {
+        position_score := 3.S
+      }.elsewhen(row_pos === 1.U) {
+        position_score := 2.S
+      }.elsewhen(row_pos === 2.U) {
+        position_score := 1.S
+      }.otherwise {
+        position_score := 0.S
+      }
+    }.elsewhen(io.In(i) === "b011".U) { // black pawn
+      // row 7 = -3, row 6 = -2, row 5 = -1, row 4- = 0
+      when(row_pos === 7.U) {
+        position_score := -3.S
+      }.elsewhen(row_pos === 6.U) {
+        position_score := -2.S
+      }.elsewhen(row_pos === 5.U) {
+        position_score := -1.S
+      }.otherwise {
+        position_score := 0.S
+      }
+    }
+    // white/black Kings don't gain position bonus 
+
+    v(i) := material_score + position_score
+  }
+
+  val total_score = v.reduceTree((x, y) => x + y)
+  io.score := total_score
+}

--- a/src/test/scala/unittests/boardeval2test.scala
+++ b/src/test/scala/unittests/boardeval2test.scala
@@ -1,0 +1,64 @@
+import chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+class boardeval2test extends AnyFlatSpec with ChiselScalatestTester {
+
+  behavior of "boardeval2_component"
+
+  it should "have score 0 on empty board" in {
+    test(new boardeval2()) { dut =>
+      for (i <- 0 to 31) {
+        dut.io.In(i).poke("b000".U)
+      }
+
+      dut.io.score.expect(
+        0.S,
+        s"the score should be 0 when there is nothing on the board"
+      )
+    }
+  }
+
+  it should "reward white pawn closer to promotion with position bonus" in {
+    test(new boardeval2()) { dut =>
+      for (i <- 0 to 31) {
+        if (i == 0) {
+          dut.io.In(i).poke("b001".U) // White pawn at row 0: +1 material + 3 position = +4
+        } else if (i == 20) {
+          dut.io.In(i).poke("b001".U) // White pawn at row 5: +1 material + 0 position = +1
+        } else {
+          dut.io.In(i).poke("b000".U)
+        }
+      }
+
+      // Material: 2 white pawns = +2
+      // Position: row 0 pawn = +3, row 5 pawn = 0
+      // Total: 2 + 3 = 5
+      dut.io.score.expect(
+        5.S,
+        s"white pawn at row 0 should get +3 position bonus, total score should be 5"
+      )
+    }
+  }
+
+  it should "combine material and position correctly for both colors" in {
+    test(new boardeval2()) { dut =>
+      for (i <- 0 to 31) {
+        if (i == 0) {
+          dut.io.In(i).poke("b001".U) // White pawn at row 0: +1 + 3 = +4
+        } else if (i == 31) {
+          dut.io.In(i).poke("b011".U) // Black pawn at row 7: -1 + (-3) = -4
+        } else {
+          dut.io.In(i).poke("b000".U)
+        }
+      }
+
+      // White: +4, Black: -4, Total: 0
+      dut.io.score.expect(
+        0.S,
+        s"material and position should combine correctly: white +4, black -4 = 0"
+      )
+    }
+  }
+}
+


### PR DESCRIPTION
… material score based.

BoardEval2 which evaluates both material and position. It adds positional bonuses to pawns based on how close they are to promotion . This should help the iterator make better decisions when the  material score of a board is tied
white: +3/+2/+1 for rows 0/1/2
black: -3/-2/-1 for rows 7/6/5